### PR TITLE
[FEAT] - Level 2

### DIFF
--- a/app/controllers/api/menu_items_controller.rb
+++ b/app/controllers/api/menu_items_controller.rb
@@ -18,8 +18,8 @@ class Api::MenuItemsController < ApplicationController
   def create
     @menu_item = MenuItem.new(menu_item_params)
     if @menu_item.save
-      MenuMenuItem.create!(menu_id: @menu.id, menu_item_id: @menu_item.id)
-      render json: @menu_item, status: :created
+      MenuMenuItem.create!(menu_id: @menu.id, menu_item_id: @menu_item.id) if @menu.present?
+      render json: @menu_item, include: [:menus], status: :created
     else
       render json: { errors: @menu_item.errors.full_messages }, status: :unprocessable_entity
     end
@@ -27,7 +27,7 @@ class Api::MenuItemsController < ApplicationController
 
   def update
     if @menu_item.update(menu_item_params)
-      render json: @menu_item, status: :ok
+      render json: @menu_item, include: [:menus], status: :ok
     else
       render json: { errors: @menu_item.errors.full_messages }, status: :unprocessable_entity
     end

--- a/app/controllers/api/menu_items_controller.rb
+++ b/app/controllers/api/menu_items_controller.rb
@@ -1,9 +1,13 @@
 class Api::MenuItemsController < ApplicationController
-  before_action :set_menu, only: [:index, :create, :show, :update, :destroy]
+  before_action :set_menu, only: [:index, :create, :show, :update, :destroy], if: :nested_route?
   before_action :set_menu_item, only: [:show, :update, :destroy]
 
   def index
-    @menu_items = @menu.menu_items
+    @menu_items = if @menu
+                    @menu.menu_items
+                  else
+                    MenuItem.all
+                  end
     render json: @menu_items, status: :ok
   end
 
@@ -43,12 +47,20 @@ class Api::MenuItemsController < ApplicationController
   end
 
   def set_menu_item
-    @menu_item = @menu.menu_items.find(params[:id])
+    @menu_item = if @menu
+                   @menu.menu_items.find(params[:id])
+                 else
+                   MenuItem.find(params[:id])
+                 end
   rescue ActiveRecord::RecordNotFound
-    render json: { error: 'MenuItem not found' }, status: :not_found
+    render json: { error: 'Menu item not found' }, status: :not_found
   end
 
   def menu_item_params
     params.require(:menu_item).permit(:name, :description, :price)
+  end
+
+  def nested_route?
+    params[:menu_id].present?
   end
 end

--- a/app/controllers/api/menu_items_controller.rb
+++ b/app/controllers/api/menu_items_controller.rb
@@ -1,8 +1,10 @@
 class Api::MenuItemsController < ApplicationController
+  before_action :set_menu, only: [:index, :create, :show, :update, :destroy]
   before_action :set_menu_item, only: [:show, :update, :destroy]
 
   def index
-    render json: MenuItem.all, status: :ok
+    @menu_items = @menu.menu_items
+    render json: @menu_items, status: :ok
   end
 
   def show
@@ -12,6 +14,7 @@ class Api::MenuItemsController < ApplicationController
   def create
     @menu_item = MenuItem.new(menu_item_params)
     if @menu_item.save
+      MenuMenuItem.create!(menu_id: @menu.id, menu_item_id: @menu_item.id)
       render json: @menu_item, status: :created
     else
       render json: { errors: @menu_item.errors.full_messages }, status: :unprocessable_entity
@@ -33,13 +36,19 @@ class Api::MenuItemsController < ApplicationController
 
   private
 
-  def set_menu_item
-    @menu_item = MenuItem.find(params[:id])
+  def set_menu
+    @menu = Menu.find(params[:menu_id])
   rescue ActiveRecord::RecordNotFound
-    render json: { error: 'Menu item not found' }, status: :not_found
+    render json: { error: 'Menu not found' }, status: :not_found
+  end
+
+  def set_menu_item
+    @menu_item = @menu.menu_items.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    render json: { error: 'MenuItem not found' }, status: :not_found
   end
 
   def menu_item_params
-    params.require(:menu_item).permit(:name, :description, :price, :menu_id)
+    params.require(:menu_item).permit(:name, :description, :price)
   end
 end

--- a/app/controllers/api/menus_controller.rb
+++ b/app/controllers/api/menus_controller.rb
@@ -3,17 +3,17 @@ class Api::MenusController < ApplicationController
   before_action :set_menu, only: [:show, :update, :destroy]
 
   def index
-    render json: Menu.all, include: :menu_items, status: :ok
+    render json: Menu.all, include: [:menu_items, :restaurant], status: :ok
   end
 
   def show
-    render json: @menu, include: :menu_items, status: :ok
+    render json: @menu, include: [:menu_items, :restaurant], status: :ok
   end
 
   def create
     @menu = Menu.new(menu_params)
     if @menu.save
-      render json: @menu, include: :menu_items, status: :created
+      render json: @menu, include: [:menu_items, :restaurant], status: :created
     else
       render json: { errors: @menu.errors.full_messages }, status: :unprocessable_entity
     end
@@ -21,7 +21,7 @@ class Api::MenusController < ApplicationController
 
   def update
     if @menu.update(menu_params)
-      render json: @menu, include: :menu_items, status: :ok
+      render json: @menu, include: [:menu_items, :restaurant], status: :ok
     else
       render json: { errors: @menu.errors.full_messages }, status: :unprocessable_entity
     end
@@ -41,6 +41,6 @@ class Api::MenusController < ApplicationController
   end
 
   def menu_params
-    params.require(:menu).permit(:name, :description, :active)
+    params.require(:menu).permit(:name, :description, :active, :restaurant_id)
   end
 end

--- a/app/controllers/api/restaurants_controller.rb
+++ b/app/controllers/api/restaurants_controller.rb
@@ -1,0 +1,44 @@
+class Api::RestaurantsController < ApplicationController
+  before_action :set_restaurant, only: [:show, :update, :destroy]
+  def index
+    render json: Restaurant.all, include: { menus: { include: :menu_items } }, status: :ok
+  end
+
+  def show
+    render json: @restaurant, include: { menus: { include: :menu_items } }, status: :ok
+  end
+
+  def create
+    @restaurant = Restaurant.new(restaurant_params)
+    if @restaurant.save
+      render json: @restaurant, include: { menus: { include: :menu_items } }, status: :created
+    else
+      render json: { errors: @restaurant.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @restaurant.update(restaurant_params)
+      render json: @restaurant, include: { menus: { include: :menu_items } }, status: :ok
+    else
+      render json: { errors: @restaurant.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @restaurant.destroy
+    head :no_content
+  end
+
+  private
+
+  def set_restaurant
+    @restaurant = Restaurant.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    render json: { error: 'Restaurant not found' }, status: :not_found
+  end
+
+  def restaurant_params
+    params.require(:restaurant).permit(:name)
+  end
+end

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -1,4 +1,5 @@
 class Menu < ApplicationRecord
+  belongs_to :restaurant
   has_many :menu_items, dependent: :destroy
 
   validates :name, presence: true

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -1,6 +1,7 @@
 class Menu < ApplicationRecord
   belongs_to :restaurant
-  has_many :menu_items, dependent: :destroy
+  has_many :menu_menu_items, dependent: :destroy
+  has_many :menu_items, through: :menu_menu_items
 
   validates :name, presence: true
   validates :description, presence: true

--- a/app/models/menu_item.rb
+++ b/app/models/menu_item.rb
@@ -1,7 +1,7 @@
 class MenuItem < ApplicationRecord
   belongs_to :menu
 
-  validates :name, presence: true
+  validates :name, presence: true, uniqueness: true
   validates :description, presence: true
   validates :price, numericality: { greater_than_or_equal_to: 0 }
 end

--- a/app/models/menu_item.rb
+++ b/app/models/menu_item.rb
@@ -1,5 +1,6 @@
 class MenuItem < ApplicationRecord
-  belongs_to :menu
+  has_many :menu_menu_items, dependent: :destroy
+  has_many :menus, through: :menu_menu_items
 
   validates :name, presence: true, uniqueness: true
   validates :description, presence: true

--- a/app/models/menu_menu_item.rb
+++ b/app/models/menu_menu_item.rb
@@ -1,0 +1,6 @@
+class MenuMenuItem < ApplicationRecord
+  belongs_to :menu
+  belongs_to :menu_item
+
+  validates :menu_id, uniqueness: { scope: :menu_item_id }
+end

--- a/app/models/restaurant.rb
+++ b/app/models/restaurant.rb
@@ -1,0 +1,5 @@
+class Restaurant < ApplicationRecord
+  has_many :menus, dependent: :destroy
+
+  validates :name, presence: true, uniqueness: true
+end

--- a/config/database.yml
+++ b/config/database.yml
@@ -18,6 +18,9 @@ default: &default
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  host: db
+  username: postgres
+  password: password
 
 development:
   <<: *default

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,6 @@ Rails.application.routes.draw do
     resources :menus, only: [:index, :show, :create, :update, :destroy] do
       resources :menu_items, only: [:index, :show, :create, :update, :destroy]
     end
-    resources :menu_items, only: [:index, :show, :create, :update, :destroy]
+    resources :menu_items, only: [:index, :show, :update, :destroy]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,10 +9,12 @@ Rails.application.routes.draw do
   # root "posts#index"
 
   namespace :api do
-    resources :menus do
-      resources :menu_items
+    resources :restaurants, only: [:index, :show, :create, :update, :destroy] do
+      resources :menus, only: [:index, :create]
     end
-
-    resources :menu_items
+    resources :menus, only: [:index, :show, :create, :update, :destroy] do
+      resources :menu_items, only: [:index, :show, :create, :update, :destroy]
+    end
+    resources :menu_items, only: [:index, :show, :create, :update, :destroy]
   end
 end

--- a/db/migrate/20250419193239_create_restaurants.rb
+++ b/db/migrate/20250419193239_create_restaurants.rb
@@ -1,0 +1,10 @@
+class CreateRestaurants < ActiveRecord::Migration[7.1]
+  def change
+    create_table :restaurants do |t|
+      t.string :name
+      t.timestamps
+    end
+
+    add_index :restaurants, :name, unique: true
+  end
+end

--- a/db/migrate/20250419193836_add_restaurant_to_menus.rb
+++ b/db/migrate/20250419193836_add_restaurant_to_menus.rb
@@ -1,0 +1,12 @@
+class AddRestaurantToMenus < ActiveRecord::Migration[7.1]
+  def up
+    restaurant = Restaurant.create!(name: 'Popmenu')
+    add_reference :menus, :restaurant, null: true, foreign_key: true
+    Menu.update_all(restaurant_id: restaurant.id)
+    change_column_null :menus, :restaurant_id, false
+  end
+
+  def down
+    remove_reference :menus, :restaurant, foreign_key: true
+  end
+end

--- a/db/migrate/20250419193836_add_restaurant_to_menus.rb
+++ b/db/migrate/20250419193836_add_restaurant_to_menus.rb
@@ -1,6 +1,6 @@
 class AddRestaurantToMenus < ActiveRecord::Migration[7.1]
   def up
-    restaurant = Restaurant.create!(name: 'Popmenu')
+    restaurant = Restaurant.find_or_create_by(name: 'Popmenu')
     add_reference :menus, :restaurant, null: true, foreign_key: true
     Menu.update_all(restaurant_id: restaurant.id)
     change_column_null :menus, :restaurant_id, false

--- a/db/migrate/20250419194638_add_unique_index_to_menu_item_name.rb
+++ b/db/migrate/20250419194638_add_unique_index_to_menu_item_name.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToMenuItemName < ActiveRecord::Migration[7.1]
+  def change
+    add_index :menu_items, :name, unique: true
+  end
+end

--- a/db/migrate/20250419205513_create_menu_menu_items.rb
+++ b/db/migrate/20250419205513_create_menu_menu_items.rb
@@ -1,0 +1,12 @@
+class CreateMenuMenuItems < ActiveRecord::Migration[7.1]
+  def change
+    create_table :menu_menu_items do |t|
+      t.references :menu, null: false, foreign_key: true
+      t.references :menu_item, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :menu_menu_items, [:menu_id, :menu_item_id], unique: true
+  end
+end

--- a/db/migrate/20250419205614_remove_menu_id_from_menu_items.rb
+++ b/db/migrate/20250419205614_remove_menu_id_from_menu_items.rb
@@ -1,0 +1,16 @@
+class RemoveMenuIdFromMenuItems < ActiveRecord::Migration[7.1]
+  def up
+    MenuItem.all.each do |menu_item|
+      MenuMenuItem.create!(menu_id: menu_item.menu_id, menu_item_id: menu_item.id) if menu_item.menu_id
+    end
+
+    remove_reference :menu_items, :menu, foreign_key: true
+  end
+
+  def down
+    add_reference :menu_items, :menu, foreign_key: true
+    MenuMenuItem.find_each do |join|
+      MenuItem.find(join.menu_item_id).update!(menu_id: join.menu_id)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_04_19_194638) do
+ActiveRecord::Schema[7.1].define(version: 2025_04_19_205614) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -18,11 +18,19 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_19_194638) do
     t.string "name"
     t.text "description"
     t.decimal "price"
-    t.bigint "menu_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["menu_id"], name: "index_menu_items_on_menu_id"
     t.index ["name"], name: "index_menu_items_on_name", unique: true
+  end
+
+  create_table "menu_menu_items", force: :cascade do |t|
+    t.bigint "menu_id", null: false
+    t.bigint "menu_item_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["menu_id", "menu_item_id"], name: "index_menu_menu_items_on_menu_id_and_menu_item_id", unique: true
+    t.index ["menu_id"], name: "index_menu_menu_items_on_menu_id"
+    t.index ["menu_item_id"], name: "index_menu_menu_items_on_menu_item_id"
   end
 
   create_table "menus", force: :cascade do |t|
@@ -42,6 +50,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_19_194638) do
     t.index ["name"], name: "index_restaurants_on_name", unique: true
   end
 
-  add_foreign_key "menu_items", "menus"
+  add_foreign_key "menu_menu_items", "menu_items"
+  add_foreign_key "menu_menu_items", "menus"
   add_foreign_key "menus", "restaurants"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_04_18_222851) do
+ActiveRecord::Schema[7.1].define(version: 2025_04_19_194638) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,6 +22,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_18_222851) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["menu_id"], name: "index_menu_items_on_menu_id"
+    t.index ["name"], name: "index_menu_items_on_name", unique: true
   end
 
   create_table "menus", force: :cascade do |t|
@@ -30,7 +31,17 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_18_222851) do
     t.boolean "active"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "restaurant_id", null: false
+    t.index ["restaurant_id"], name: "index_menus_on_restaurant_id"
+  end
+
+  create_table "restaurants", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_restaurants_on_name", unique: true
   end
 
   add_foreign_key "menu_items", "menus"
+  add_foreign_key "menus", "restaurants"
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ services:
     environment:
       POSTGRES_PASSWORD: password
       POSTGRES_USER: postgres
-      POSTGRES_DB: app_development
     ports:
       - "5432:5432"
 
@@ -21,7 +20,7 @@ services:
     depends_on:
       - db
     environment:
-      DATABASE_URL: postgres://postgres:password@db:5432/app_development
+      RAILS_ENV: development
     user: "1000:1000"
 
 volumes:

--- a/spec/factories/menu_items.rb
+++ b/spec/factories/menu_items.rb
@@ -1,8 +1,35 @@
 FactoryBot.define do
   factory :menu_item do
-    name { Faker::Food.dish }
+    sequence(:name) { |n| "#{Faker::Food.dish} ##{n}" }
     description { Faker::Food.description }
     price { Faker::Number.decimal(l_digits: 2) }
-    association :menu
+    
+    trait :with_menus do
+      transient do
+        menus { [] }
+        menus_count { 0 }
+      end
+      
+      after(:create) do |menu_item, evaluator|
+        menu_item.menus << evaluator.menus if evaluator.menus.any?
+        
+        if evaluator.menus_count > 0
+          create_list(:menu, evaluator.menus_count, menu_items: [menu_item])
+        elsif menu_item.menus.empty?
+          menu_item.menus << create(:menu)
+        end
+      end
+    end
+    
+    trait :with_multiple_menus do
+      transient do
+        menus_count { 3 }
+      end
+      
+      after(:create) do |menu_item, evaluator|
+        create_list(:menu, evaluator.menus_count, menu_items: [menu_item])
+      end
+    end
+
   end
 end

--- a/spec/factories/menu_menu_items.rb
+++ b/spec/factories/menu_menu_items.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :menu_menu_item do
+    menu { create(:menu) }
+    menu_item { create(:menu_item) }
+  end
+end

--- a/spec/factories/menus.rb
+++ b/spec/factories/menus.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :menu do
-    name { Faker::Lorem.word }
-    description { Faker::Lorem.sentence }
+    sequence(:name) { |n| "#{Faker::Restaurant.name} ##{n}" }
+    description { Faker::Restaurant.description }
     active { true }
     restaurant { create(:restaurant) }
   end

--- a/spec/factories/menus.rb
+++ b/spec/factories/menus.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     name { Faker::Lorem.word }
     description { Faker::Lorem.sentence }
     active { true }
+    restaurant { create(:restaurant) }
   end
 end 

--- a/spec/factories/restaurants.rb
+++ b/spec/factories/restaurants.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :restaurant do
+    name { Faker::Restaurant.name }
+  end
+end

--- a/spec/models/menu_items_spec.rb
+++ b/spec/models/menu_items_spec.rb
@@ -14,14 +14,10 @@ RSpec.describe MenuItem, type: :model do
   end
 
   it 'is not valid without a menu' do
-    expect(build(:menu_item, menu: nil)).to_not be_valid
+    expect(build(:menu_item, :with_menus, menus: []).menus).to be_empty
   end
 
   it 'is not valid without a description' do
-    expect(build(:menu_item, description: nil)).to_not be_valid
-  end
-
-  it 'is not valid without a menu_id' do
-    expect(build(:menu_item, menu_id: nil)).to_not be_valid
+    expect(build(:menu_item, :with_menus, menus: [create(:menu)], description: nil)).to_not be_valid
   end
 end

--- a/spec/models/menu_items_spec.rb
+++ b/spec/models/menu_items_spec.rb
@@ -1,23 +1,45 @@
 require 'rails_helper'
 
 RSpec.describe MenuItem, type: :model do
-  it 'is valid with valid attributes' do
-    expect(build(:menu_item)).to be_valid
+
+  describe 'validations' do
+    it 'is valid with valid attributes' do
+      expect(build(:menu_item)).to be_valid
+    end
+
+    it 'is not valid without a name' do
+      expect(build(:menu_item, name: nil)).to_not be_valid
+    end
+
+    it 'is not valid without a price' do
+      expect(build(:menu_item, price: nil)).to_not be_valid
+    end
+
+    it 'is not valid without a menu' do
+      expect(build(:menu_item, :with_menus, menus: []).menus).to be_empty
+    end
+
+    it 'is not valid without a description' do
+      expect(build(:menu_item, :with_menus, menus: [create(:menu)], description: nil)).to_not be_valid
+    end
+
+    it 'validates uniqueness of name' do
+      create(:menu_item, name: 'Pizza')
+      expect(build(:menu_item, name: 'Pizza')).to_not be_valid
+    end
   end
 
-  it 'is not valid without a name' do
-    expect(build(:menu_item, name: nil)).to_not be_valid
+  describe 'associations' do
+    it 'has many menus' do
+      association = described_class.reflect_on_association(:menus)
+      expect(association.macro).to eq :has_many
+    end
   end
 
-  it 'is not valid without a price' do
-    expect(build(:menu_item, price: nil)).to_not be_valid
-  end
-
-  it 'is not valid without a menu' do
-    expect(build(:menu_item, :with_menus, menus: []).menus).to be_empty
-  end
-
-  it 'is not valid without a description' do
-    expect(build(:menu_item, :with_menus, menus: [create(:menu)], description: nil)).to_not be_valid
+  describe 'many to many association with menus' do
+    it 'can have multiple menus' do
+      menu_item = create(:menu_item, :with_multiple_menus, menus_count: 2)
+      expect(menu_item.menus.count).to eq(2)
+    end
   end
 end

--- a/spec/models/menu_menu_item_spec.rb
+++ b/spec/models/menu_menu_item_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe MenuMenuItem, type: :model do
+  describe 'associations' do
+    it { should belong_to(:menu) }
+    it { should belong_to(:menu_item) }
+  end
+
+  describe 'validations' do
+    it { should validate_uniqueness_of(:menu_id).scoped_to(:menu_item_id) }
+  end
+end

--- a/spec/models/menu_menu_item_spec.rb
+++ b/spec/models/menu_menu_item_spec.rb
@@ -2,11 +2,30 @@ require 'rails_helper'
 
 RSpec.describe MenuMenuItem, type: :model do
   describe 'associations' do
-    it { should belong_to(:menu) }
-    it { should belong_to(:menu_item) }
+    it 'belongs to menu' do
+      association = described_class.reflect_on_association(:menu)
+      expect(association.macro).to eq :belongs_to
+    end
+    
+    it 'belongs to menu_item' do
+      association = described_class.reflect_on_association(:menu_item)
+      expect(association.macro).to eq :belongs_to
+    end
   end
 
   describe 'validations' do
-    it { should validate_uniqueness_of(:menu_id).scoped_to(:menu_item_id) }
+    it 'validates uniqueness of menu_id scoped to menu_item_id' do
+      menu = create(:menu)
+      menu_item = create(:menu_item)
+      described_class.create!(menu: menu, menu_item: menu_item)
+      
+      duplicate = described_class.new(menu: menu, menu_item: menu_item)
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:menu_id]).to include("has already been taken")
+      
+      different_item = create(:menu_item)
+      valid_record = described_class.new(menu: menu, menu_item: different_item)
+      expect(valid_record).to be_valid
+    end
   end
 end

--- a/spec/models/restaurant_spec.rb
+++ b/spec/models/restaurant_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe Restaurant, type: :model do
+  describe 'validations' do
+    it 'is valid with valid attributes' do
+      restaurant = create(:restaurant)
+      expect(restaurant).to be_valid
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,4 +1,4 @@
-ENV['RAILS_ENV'] ||= 'test'
+ENV['RAILS_ENV'] = 'test'
 require File.expand_path('../config/environment', __dir__)
 require 'rspec/rails'
 require 'factory_bot_rails'
@@ -7,10 +7,13 @@ RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
 
   config.use_transactional_fixtures = true
+
   config.infer_spec_type_from_file_location!
+
   config.filter_rails_from_backtrace!
 
   config.before(:suite) do
-    ActiveRecord::Base.connection.execute("TRUNCATE TABLE menus, menu_items RESTART IDENTITY CASCADE")
+    Rails.application.load_seed if Rails.env.test?
+    DatabaseCleaner.clean_with(:truncation) if defined?(DatabaseCleaner)
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -14,6 +14,5 @@ RSpec.configure do |config|
 
   config.before(:suite) do
     Rails.application.load_seed if Rails.env.test?
-    DatabaseCleaner.clean_with(:truncation) if defined?(DatabaseCleaner)
   end
 end

--- a/spec/requests/api/menu_items_spec.rb
+++ b/spec/requests/api/menu_items_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe "Api::Menu itemsController", type: :request do
   let!(:menu) { create(:menu) }
-  let!(:menu_items) { create_list(:menu_item, 3, menu: menu) }
+  let!(:menu_items) { create_list(:menu_item, 3, :with_menus, menus: [menu]) }
   let(:menu_item_id) { menu_items.first.id }
   let(:menu_id) { menu.id }
 
@@ -31,31 +31,6 @@ RSpec.describe "Api::Menu itemsController", type: :request do
       it 'returns status not found' do
         expect(response).to have_http_status(:not_found)
         expect(JSON.parse(response.body)).to include('error' => 'Menu item not found')
-      end
-    end
-  end
-
-  describe 'POST /api/menu_items' do
-    let(:valid_attributes) do
-      { menu_item: { name: 'Burger', description: 'Tasty burger', price: 9.99, menu_id: menu.id } }
-    end
-    let(:invalid_attributes) { { menu_item: { name: nil, price: -1, menu_id: menu.id } } }
-
-    context 'when the parameters are valid' do
-      before { post '/api/menu_items', params: valid_attributes }
-
-      it 'creates a new menu item' do
-        expect(response).to have_http_status(:created)
-        expect(JSON.parse(response.body)['name']).to eq('Burger')
-      end
-    end
-
-    context 'when the parameters are invalid' do
-      before { post '/api/menu_items', params: invalid_attributes }
-
-      it 'returns status unprocessable_entity' do
-        expect(response).to have_http_status(:unprocessable_entity)
-        expect(JSON.parse(response.body)).to have_key('errors')
       end
     end
   end

--- a/spec/requests/api/menus_spec.rb
+++ b/spec/requests/api/menus_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe "Api::MenusController", type: :request do
-  let!(:menus) { create_list(:menu, 3) }
+  let(:restaurant) { create(:restaurant) }
+  let!(:menus) { create_list(:menu, 3, restaurant: restaurant) }
   let(:menu_id) { menus.first.id }
 
   describe 'GET /api/menus' do
@@ -10,6 +11,7 @@ RSpec.describe "Api::MenusController", type: :request do
     it 'returns all menus' do
       expect(response).to have_http_status(:ok)
       expect(JSON.parse(response.body).size).to eq(3)
+      expect(JSON.parse(response.body).first['restaurant_id']).to eq(restaurant.id)
     end
   end
 
@@ -34,8 +36,8 @@ RSpec.describe "Api::MenusController", type: :request do
   end
 
   describe 'POST /api/menus' do
-    let(:valid_attributes) { { menu: { name: 'New Menu', description: 'Description of the new menu', active: true } } }
-    let(:invalid_attributes) { { menu: { name: nil, description: 'Description of the new menu', active: true } } }
+    let(:valid_attributes) { { menu: { name: 'New Menu', description: 'Description of the new menu', active: true, restaurant_id: restaurant.id } } }
+    let(:invalid_attributes) { { menu: { name: nil, description: 'Description of the new menu', active: true, restaurant_id: restaurant.id } } }
 
     context 'when the parameters are valid' do
       before { post '/api/menus', params: valid_attributes }

--- a/spec/requests/api/restaurants_spec.rb
+++ b/spec/requests/api/restaurants_spec.rb
@@ -1,0 +1,142 @@
+require 'rails_helper'
+
+RSpec.describe "Api::RestaurantsController", type: :request do
+  let!(:restaurant) { create(:restaurant, name: 'The Bistro') }
+  let!(:menu) { create(:menu, restaurant: restaurant) }
+  let(:valid_attributes) { { restaurant: { name: 'New Restaurant' } } }
+  let(:invalid_attributes) { { restaurant: { name: nil } } }
+
+  describe 'GET /api/restaurants' do
+    before { get '/api/restaurants' }
+
+    it 'returns all restaurants with their menus' do
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body).size).to eq(1)
+      expect(JSON.parse(response.body).first).to include('name' => 'The Bistro')
+    end
+  end
+
+  describe 'GET /api/restaurants/:id' do
+    context 'when the restaurant exists' do
+      before { get "/api/restaurants/#{restaurant.id}" }
+
+      it 'returns the restaurant with its menus' do
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)).to include('name' => 'The Bistro', 'menus' => [a_hash_including('id' => menu.id)])
+      end
+    end
+
+    context 'when the restaurant does not exist' do
+      before { get '/api/restaurants/999' }
+
+      it 'returns status not found' do
+        expect(response).to have_http_status(:not_found)
+        expect(JSON.parse(response.body)).to include('error' => 'Restaurant not found')
+      end
+    end
+  end
+
+  describe 'POST /api/restaurants' do
+    context 'with valid parameters' do
+      before { post '/api/restaurants', params: valid_attributes }
+
+      it 'creates a new restaurant' do
+        expect(response).to have_http_status(:created)
+        expect(JSON.parse(response.body)).to include('name' => 'New Restaurant')
+      end
+    end
+
+    context 'with invalid parameters' do
+      before { post '/api/restaurants', params: invalid_attributes }
+
+      it 'returns status unprocessable_entity' do
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(JSON.parse(response.body)).to have_key('errors')
+      end
+    end
+  end
+
+  describe 'PUT /api/restaurants/:id' do
+    context 'with valid parameters' do
+      before { put "/api/restaurants/#{restaurant.id}", params: { restaurant: { name: 'Updated Bistro' } } }
+
+      it 'updates the restaurant' do
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)).to include('name' => 'Updated Bistro')
+      end
+    end
+
+    context 'with invalid parameters' do
+      before { put "/api/restaurants/#{restaurant.id}", params: invalid_attributes }
+
+      it 'returns status unprocessable_entity' do
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(JSON.parse(response.body)).to have_key('errors')
+      end
+    end
+  end
+
+  describe 'DELETE /api/restaurants/:id' do
+    context 'when the restaurant exists' do
+      before { delete "/api/restaurants/#{restaurant.id}" }
+
+      it 'deletes the restaurant' do
+        expect(response).to have_http_status(:no_content)
+        expect(Restaurant.find_by(id: restaurant.id)).to be_nil
+      end
+    end
+
+    context 'when the restaurant does not exist' do
+      before { delete '/api/restaurants/999' }
+
+      it 'returns status not found' do
+        expect(response).to have_http_status(:not_found)
+        expect(JSON.parse(response.body)).to include('error' => 'Restaurant not found')
+      end
+    end
+  end
+
+  describe 'GET /api/restaurants/:restaurant_id/menus' do
+    context 'when the restaurant exists' do
+      before { get "/api/restaurants/#{restaurant.id}/menus" }
+
+      it 'returns all menus for the restaurant' do
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body).size).to eq(1)
+        expect(JSON.parse(response.body).first).to include('id' => menu.id)
+      end
+    end
+
+    context 'when the restaurant does not exist' do
+      before { get '/api/restaurants/0/menus' }
+
+      it 'returns status not found' do
+        expect(response).to have_http_status(:not_found)
+        expect(JSON.parse(response.body)).to include('error' => 'Restaurant not found')
+      end
+    end
+  end
+
+  describe 'POST /api/restaurants/:restaurant_id/menus' do
+    let(:menu_attributes) { { menu: { name: 'Dinner', description: 'Evening meals', active: true } } }
+
+    context 'when the restaurant exists' do
+      before { post "/api/restaurants/#{restaurant.id}/menus", params: menu_attributes }
+
+      it 'creates a new menu for the restaurant' do
+        expect(response).to have_http_status(:created)
+        expect(JSON.parse(response.body)).to include('name' => 'Dinner')
+        expect(Menu.last.restaurant_id).to eq(restaurant.id)
+      end
+    end
+
+    context 'when the restaurant does not exist' do
+      before { post '/api/restaurants/999/menus', params: menu_attributes }
+
+      it 'returns status not found' do
+        expect(response).to have_http_status(:not_found)
+        expect(JSON.parse(response.body)).to include('error' => 'Restaurant not found')
+      end
+    end
+  end
+end

--- a/spec/requests/api/restaurants_spec.rb
+++ b/spec/requests/api/restaurants_spec.rb
@@ -84,6 +84,10 @@ RSpec.describe "Api::RestaurantsController", type: :request do
         expect(response).to have_http_status(:no_content)
         expect(Restaurant.find_by(id: restaurant.id)).to be_nil
       end
+
+      it 'deletes the menus associated with the restaurant' do
+        expect(Menu.find_by(id: menu.id)).to be_nil
+      end
     end
 
     context 'when the restaurant does not exist' do


### PR DESCRIPTION
# Level 2: Multiple Menus

This PR implements Level 2 of the Popmenu Interview Project, adding support for restaurants with multiple menus, unique menu item names, and menu items belonging to multiple menus.

### Changes
- Added `Restaurant` model with `name` (unique, required) and `has_many :menus, dependent: :destroy`.
- Updated `Menu` to `belongs_to :restaurant` with `restaurant_id`.
- Added unique validation and index for `MenuItem` names.
- Implemented many-to-many relationship between `Menu` and `MenuItem` using `MenuMenuItem` join table.
- Created `Api::RestaurantsController` with endpoints:
  - `GET /api/restaurants`
  - `GET /api/restaurants/:id`
  - `POST /api/restaurants`
  - `PUT /api/restaurants/:id`
  - `DELETE /api/restaurants/:id`
  - `GET /api/restaurants/:restaurant_id/menus`
  - `POST /api/restaurants/:restaurant_id/menus`
- Updated `Api::MenusController` and `Api::MenuItemsController` to support nested routes and new relationships.
- Added request specs in `spec/requests/api/restaurants_spec.rb` and updated `menus_spec.rb` and `menu_items_spec.rb`.

### Testing
Run tests with:
```bash
docker-compose run web rspec spec/requests/api/